### PR TITLE
Handle '--' like builtin getopts

### DIFF
--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -22,6 +22,8 @@ getopts_long() {
 
     printf -v "${optvar}" "%s" "${OPTARG%%=*}"
 
+    [[ "${!optvar}" != '-' ]] || return 1  # Handle '--'
+
     if [[ "${optspec_long}" =~ (^|[[:space:]])${!optvar}:([[:space:]]|$) ]]; then
         OPTARG="${OPTARG#${!optvar}}"
         OPTARG="${OPTARG#=}"


### PR DESCRIPTION
Terminate further argument parsing when '--' is encountered.