### PR TITLE
Redeclare OPTARG for valid long option without argument

### DIFF
--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -40,7 +40,8 @@ getopts_long() {
             fi
         fi
     elif [[ "${optspec_long}" =~ (^|[[:space:]])${!optvar}([[:space:]]|$) ]]; then
-        OPTARG=
+        unset OPTARG
+        declare -g OPTARG
     else
         # Invalid option
         if [[ "${optspec_short:0:1}" == ':' ]]; then

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -40,7 +40,7 @@ getopts_long() {
             fi
         fi
     elif [[ "${optspec_long}" =~ (^|[[:space:]])${!optvar}([[:space:]]|$) ]]; then
-        unset OPTARG
+        OPTARG=
     else
         # Invalid option
         if [[ "${optspec_short:0:1}" == ':' ]]; then


### PR DESCRIPTION
This PR redeclares OPTARG when `getopts_long` encounters a valid long option without a required argument (e.g. `foo --alpha`).

I believe this matches the behavior of the builtin `getopts` command for valid short options without an argument (e.g. `foo -a`) if you compare both with `declare -p OPTARG` in the while loop.