### PR TITLE
Fix default argument logic

### DIFF
--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -9,7 +9,7 @@ getopts_long() {
     shift 2
 
     if [[ "${#}" == 0 ]]; then
-        local -i index
+        local -i i
         local -a args=()
         for (( i = BASH_ARGC[0] + BASH_ARGC[1] - 1; i >= BASH_ARGC[0]; i-- )); do
             args+=("${BASH_ARGV[i]}")

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -9,10 +9,10 @@ getopts_long() {
     shift 2
 
     if [[ "${#}" == 0 ]]; then
-        local args=()
-        while [[ ${#BASH_ARGV[@]} -gt ${#args[@]} ]]; do
-            local index=$(( ${#BASH_ARGV[@]} - ${#args[@]} - 1 ))
-            args[${#args[@]}]="${BASH_ARGV[${index}]}"
+        local -i index
+        local -a args=()
+        for (( i = BASH_ARGC[0] + BASH_ARGC[1] - 1; i >= BASH_ARGC[0]; i-- )); do
+            args+=("${BASH_ARGV[i]}")
         done
         set -- "${args[@]}"
     fi


### PR DESCRIPTION
This PR updates the logic executed when arguments are not explicitly passed to `getopts_long` and instead they are determined from the call stack (using `BASH_ARGV`), which attempts to match the default argument behavior of the builtin `getopts` command.

Based on my tests, the updated logic fixes all the bugs I found, e.g. when calling `getopts_long` within nested functions, etc.

Also, while testing, I noticed the use of `BASH_ARGV` requires `shopt -s extdebug` to be enabled. Also, the logic may not work in all scenarios, e.g. when the arguments have been shifted, etc. However, this was always the case, and is not new to the changes in this PR.