### PR TITLE
Prevent error if !OPTIND is unbound

### DIFF
--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -40,7 +40,8 @@ getopts_long() {
             fi
         fi
     elif [[ "${optspec_long}" =~ (^|[[:space:]])${!optvar}([[:space:]]|$) ]]; then
-        OPTARG=
+        unset OPTARG
+        declare -g OPTARG
     else
         # Invalid option
         if [[ "${optspec_short:0:1}" == ':' ]]; then

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -28,10 +28,9 @@ getopts_long() {
 
         # Missing argument
         if [[ -z "${OPTARG}" ]]; then
-            OPTARG="${!OPTIND}" && OPTIND=$(( OPTIND + 1 ))
-            [[ -z "${OPTARG}" ]] || return 0
-
-            if [[ "${optspec_short:0:1}" == ':' ]]; then
+            if [[ -n "${!OPTIND:-}" ]]; then
+                OPTARG="${!OPTIND}" && OPTIND=$(( OPTIND + 1 ))
+            elif [[ "${optspec_short:0:1}" == ':' ]]; then
                 OPTARG="${!optvar}" && printf -v "${optvar}" ':'
             else
                 [[ "${OPTERR}" == 0 ]] || \

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -9,7 +9,7 @@ getopts_long() {
     shift 2
 
     if [[ "${#}" == 0 ]]; then
-        local -i index
+        local -i i
         local -a args=()
         for (( i = BASH_ARGC[0] + BASH_ARGC[1] - 1; i >= BASH_ARGC[0]; i-- )); do
             args+=("${BASH_ARGV[i]}")

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -40,7 +40,7 @@ getopts_long() {
             fi
         fi
     elif [[ "${optspec_long}" =~ (^|[[:space:]])${!optvar}([[:space:]]|$) ]]; then
-        unset OPTARG
+        OPTARG=
     else
         # Invalid option
         if [[ "${optspec_short:0:1}" == ':' ]]; then

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -9,10 +9,10 @@ getopts_long() {
     shift 2
 
     if [[ "${#}" == 0 ]]; then
-        local args=()
-        while [[ ${#BASH_ARGV[@]} -gt ${#args[@]} ]]; do
-            local index=$(( ${#BASH_ARGV[@]} - ${#args[@]} - 1 ))
-            args[${#args[@]}]="${BASH_ARGV[${index}]}"
+        local -i index
+        local -a args=()
+        for (( i = BASH_ARGC[0] + BASH_ARGC[1] - 1; i >= BASH_ARGC[0]; i-- )); do
+            args+=("${BASH_ARGV[i]}")
         done
         set -- "${args[@]}"
     fi


### PR DESCRIPTION
This PR adds a check that prevents an error when nounset is enabled (`set -u`) and `!OPTIND` is unbound, i.e. when there are no more arguments left to process and `getopts_long` encounters a final option that is missing a required argument. This matches the behavior of the builtin `getopts` command.