### PR TITLE
[GH-26] Added tests to ensure that long options can start with a hyphen character

### DIFF
--- a/test/bats/github_26a.bats
+++ b/test/bats/github_26a.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+export GETOPTS_LONG_TEST_BIN='getopts_long-longspec_with_dash'
+
+@test "${FEATURE}: toggle, silent" {
+    compare '-t' \
+            '---'
+}
+@test "${FEATURE}: toggle, verbose" {
+    compare '-t' \
+            '---'
+}
+
+@test "${FEATURE}: double toggle, silent" {
+    compare '-tt' \
+            '--- --toggle' \
+            '/^OPTIND: /d'
+    expect "${bash_getopts[6]}" == 'OPTIND: 2'
+    expect "${getopts_long[6]}" == 'OPTIND: 3'
+}
+@test "${FEATURE}: double toggle, verbose" {
+    compare '-tt' \
+            '--- --toggle' \
+            '/^OPTIND: /d'
+    expect "${bash_getopts[6]}" == 'OPTIND: 2'
+    expect "${getopts_long[6]}" == 'OPTIND: 3'
+}

--- a/test/bats/github_26b.bats
+++ b/test/bats/github_26b.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+export GETOPTS_LONG_TEST_BIN='getopts_long-longspec_with_dash_colon'
+
+@test "${FEATURE}: option, silent" {
+    compare '-o user_val' \
+            '--- user_val'
+}
+@test "${FEATURE}: option, verbose" {
+    compare '-o user_val' \
+            '--- user_val'
+}
+
+# geopts_long does not support option-value adjoined syntax for long options.
+# Thus, let's compare it to bash getopts command that uses an invalid option.
+@test "${FEATURE}: option with adjacent value, silent" {
+    compare '-z' \
+            '---zz' \
+            '/^INVALID OPTION/d'
+    expect "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG=z'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=-zz'
+}
+@test "${FEATURE}: option with adjacent value, verbose" {
+    compare '-z' \
+            '---zz' \
+            '/-verbose: illegal option --/d'
+    expect "${bash_getopts[1]}" =~ '-verbose: illegal option -- z'
+    expect "${getopts_long[1]}" =~ '-verbose: illegal option -- -zz'
+}

--- a/test/bats/github_26c.bats
+++ b/test/bats/github_26c.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+export GETOPTS_LONG_TEST_BIN='getopts_long-github_26'
+
+@test "${FEATURE}: toggle, silent" {
+    compare '-t user_arg' \
+            '---toggle user_arg'
+}
+@test "${FEATURE}: toggle, verbose" {
+    compare '-t user_arg' \
+            '---toggle user_arg'
+}
+
+@test "${FEATURE}: option, silent" {
+    compare '-o user_val' \
+            '---option user_val'
+}
+@test "${FEATURE}: option, verbose" {
+    compare '-o user_val' \
+            '---option user_val'
+}

--- a/test/bin/getopts_long-github_26-silent
+++ b/test/bin/getopts_long-github_26-silent
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+TOPDIR="$(cd "$(dirname "${0}")"/../.. && pwd)"
+# shellcheck disable=SC1090
+source "${TOPDIR}/lib/getopts_long.bash"
+
+while getopts_long ':to:v: toggle option: variable: -toggle -option:' OPTKEY; do
+    case ${OPTKEY} in
+        't'|'toggle'|'-toggle')
+            printf 'toggle triggered'
+            ;;
+        '-'|'o'|'option'|'-option')
+            printf 'option supplied'
+            ;;
+        'v'|'variable')
+            printf 'value supplied'
+            ;;
+        '?')
+            printf "INVALID OPTION"
+            ;;
+        ':')
+            printf "MISSING ARGUMENT"
+            ;;
+        *)
+            printf "NEVER REACHED"
+            ;;
+    esac
+    printf ' -- '
+    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+done
+
+shift $(( OPTIND - 1 ))
+
+echo "OPTERR: ${OPTERR}"
+echo "OPTKEY: ${OPTKEY}"
+echo "OPTARG: ${OPTARG}"
+echo "OPTIND: ${OPTIND}"
+echo "\$@: ${*}"

--- a/test/bin/getopts_long-github_26-verbose
+++ b/test/bin/getopts_long-github_26-verbose
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+TOPDIR="$(cd "$(dirname "${0}")"/../.. && pwd)"
+# shellcheck disable=SC1090
+source "${TOPDIR}/lib/getopts_long.bash"
+
+while getopts_long 'to:v: toggle option: variable: -toggle -option:' OPTKEY; do
+    case ${OPTKEY} in
+        't'|'toggle'|'-toggle')
+            printf 'toggle triggered'
+            ;;
+        '-'|'o'|'option'|'-option')
+            printf 'option supplied'
+            ;;
+        'v'|'variable')
+            printf 'value supplied'
+            ;;
+        '?')
+            printf "INVALID OPTION or MISSING ARGUMENT"
+            ;;
+        *)
+            printf "NEVER REACHED"
+            ;;
+    esac
+    printf ' -- '
+    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+done
+
+shift $(( OPTIND - 1 ))
+
+echo "OPTERR: ${OPTERR}"
+echo "OPTKEY: ${OPTKEY}"
+echo "OPTARG: ${OPTARG}"
+echo "OPTIND: ${OPTIND}"
+echo "\$@: ${*}"

--- a/test/bin/getopts_long-longspec_with_dash_colon-silent
+++ b/test/bin/getopts_long-longspec_with_dash_colon-silent
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+TOPDIR="$(cd "$(dirname "${0}")"/../.. && pwd)"
+# shellcheck disable=SC1090
+source "${TOPDIR}/lib/getopts_long.bash"
+
+while getopts_long ':to:v: -: toggle option: variable:' OPTKEY; do
+    case ${OPTKEY} in
+        't'|'toggle')
+            printf 'toggle triggered'
+            ;;
+        '-'|'o'|'option')
+            printf 'option supplied'
+            ;;
+        'v'|'variable')
+            printf 'value supplied'
+            ;;
+        '?')
+            printf "INVALID OPTION"
+            ;;
+        ':')
+            printf "MISSING ARGUMENT"
+            ;;
+        *)
+            printf "NEVER REACHED"
+            ;;
+    esac
+    printf ' -- '
+    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+done
+
+shift $(( OPTIND - 1 ))
+
+echo "OPTERR: ${OPTERR}"
+echo "OPTKEY: ${OPTKEY}"
+echo "OPTARG: ${OPTARG}"
+echo "OPTIND: ${OPTIND}"
+echo "\$@: ${*}"

--- a/test/bin/getopts_long-longspec_with_dash_colon-verbose
+++ b/test/bin/getopts_long-longspec_with_dash_colon-verbose
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+TOPDIR="$(cd "$(dirname "${0}")"/../.. && pwd)"
+# shellcheck disable=SC1090
+source "${TOPDIR}/lib/getopts_long.bash"
+
+while getopts_long 'to:v: -: toggle option: variable:' OPTKEY; do
+    case ${OPTKEY} in
+        't'|'toggle')
+            printf 'toggle triggered'
+            ;;
+        '-'|'o'|'option')
+            printf 'option supplied'
+            ;;
+        'v'|'variable')
+            printf 'value supplied'
+            ;;
+        '?')
+            printf "INVALID OPTION or MISSING ARGUMENT"
+            ;;
+        *)
+            printf "NEVER REACHED"
+            ;;
+    esac
+    printf ' -- '
+    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+done
+
+shift $(( OPTIND - 1 ))
+
+echo "OPTERR: ${OPTERR}"
+echo "OPTKEY: ${OPTKEY}"
+echo "OPTARG: ${OPTARG}"
+echo "OPTIND: ${OPTIND}"
+echo "\$@: ${*}"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -63,5 +63,5 @@ compare() {
     fi
 
     expect "${getopts_long_output}" == "${bash_getopts_output}"
-    expect "${getopts_long[0]}" == "${bash_getopts[0]}"
+    expect "Exit status: ${getopts_long[0]}" == "Exit status: ${bash_getopts[0]}"
 }


### PR DESCRIPTION
This resolves https://github.com/UrsaDK/getopts_long/issues/26 by ensuring that it is possible to define the hyphen (`-`) and options starting with a hyphen (`-XXX`) as valid long options in getopts_long OPTSPEC. 

On the command line, this allows getopts_long to support both: the `---` as a standalone option, and options starting with three hyphens, such as `—XXX`.