### PR TITLE
Ensures the handling of OPTARG is consistent with Bash’s getopts

### DIFF
--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -46,6 +46,7 @@ getopts_long() {
         fi
     elif [[ " ${optspec_long} " == *" ${!optvar} "* ]]; then
         unset OPTARG
+        declare -g OPTARG
     else
         # Invalid option
         if [[ "${optspec_short:0:1}" == ':' ]]; then

--- a/test/bats/github_15a.bats
+++ b/test/bats/github_15a.bats
@@ -82,7 +82,7 @@ load ../test_helper
     compare '-o-- -t user_arg' \
             '--option-- --toggle user_arg' \
             '1{/(option supplied|INVALID OPTION)/d}'
-    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG=--'
+    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG="--"'
     expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="option--"'
 }
 @test "${FEATURE}: long option, verbose" {
@@ -90,6 +90,6 @@ load ../test_helper
             '--option-- --toggle user_arg' \
             '1{/(option supplied|illegal option)/d}' \
             '2{/^INVALID OPTION or MISSING ARGUMENT/d}'
-    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG=--'
+    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG="--"'
     expect "${getopts_long[1]}" =~ "getopts_long-verbose: illegal option -- option--$"
 }

--- a/test/bats/github_15a.bats
+++ b/test/bats/github_15a.bats
@@ -37,9 +37,9 @@ load ../test_helper
             '--toggle-- --toggle user_arg' \
             '1{/^toggle triggered/d}' \
             '/^INVALID OPTION/d'
-    expect "${bash_getopts[2]}" == 'INVALID OPTION -- OPTARG=-'
-    expect "${bash_getopts[3]}" == 'INVALID OPTION -- OPTARG=-'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=toggle--'
+    expect "${bash_getopts[2]}" == 'INVALID OPTION -- OPTARG="-"'
+    expect "${bash_getopts[3]}" == 'INVALID OPTION -- OPTARG="-"'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="toggle--"'
     expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
     expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG'
     expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG'
@@ -83,7 +83,7 @@ load ../test_helper
             '--option-- --toggle user_arg' \
             '1{/(option supplied|INVALID OPTION)/d}'
     expect "${bash_getopts[1]}" == 'option supplied -- OPTARG=--'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=option--'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="option--"'
 }
 @test "${FEATURE}: long option, verbose" {
     compare '-o-- -t user_arg' \

--- a/test/bats/github_15a.bats
+++ b/test/bats/github_15a.bats
@@ -37,12 +37,12 @@ load ../test_helper
             '--toggle-- --toggle user_arg' \
             '1{/^toggle triggered/d}' \
             '/^INVALID OPTION/d'
-    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG is unset'
     expect "${bash_getopts[2]}" == 'INVALID OPTION -- OPTARG=-'
     expect "${bash_getopts[3]}" == 'INVALID OPTION -- OPTARG=-'
-    expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG is unset'
     expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=toggle--'
-    expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG is unset'
+    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
+    expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG'
+    expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG'
 }
 @test "${FEATURE}: long toggle, verbose" {
     compare '-t-- -t user_arg' \
@@ -52,12 +52,12 @@ load ../test_helper
             '5{/^INVALID OPTION or MISSING ARGUMENT/d}' \
             's/getopts[[:alpha:]_-]*/GETOPTS-NORMALISED/' \
             's/(illegal option --) (-|toggle--)/\1 TOGGLE-NORMALISED/'
-    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG is unset'
+    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
     expect "${bash_getopts[2]}" =~ 'getopts-verbose: illegal option -- -$'
     expect "${bash_getopts[4]}" =~ 'getopts-verbose: illegal option -- -$'
-    expect "${bash_getopts[6]}" == 'toggle triggered -- OPTARG is unset'
+    expect "${bash_getopts[6]}" == 'toggle triggered -- OPTARG'
     expect "${getopts_long[1]}" =~ 'getopts_long-verbose: illegal option -- toggle--$'
-    expect "${getopts_long[3]}" == 'toggle triggered -- OPTARG is unset'
+    expect "${getopts_long[3]}" == 'toggle triggered -- OPTARG'
 }
 
 # Both implementations should see:

--- a/test/bats/github_15b.bats
+++ b/test/bats/github_15b.bats
@@ -85,7 +85,7 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
     compare '-o-- -t user_arg' \
             '--option-- --toggle user_arg' \
             '1{/(option supplied|INVALID OPTION)/d}'
-    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG=--'
+    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG="--"'
     expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="option--"'
 }
 @test "${FEATURE}: long option, verbose" {
@@ -93,6 +93,6 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
             '--option-- --toggle user_arg' \
             '1{/(option supplied|illegal option)/d}' \
             '2{/^INVALID OPTION or MISSING ARGUMENT/d}'
-    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG=--'
+    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG="--"'
     expect "${getopts_long[1]}" =~ "getopts_long-\w+-verbose: illegal option -- option--$"
 }

--- a/test/bats/github_15b.bats
+++ b/test/bats/github_15b.bats
@@ -40,12 +40,12 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
             '--toggle-- --toggle user_arg' \
             '1{/^toggle triggered/d}' \
             '/^INVALID OPTION/d'
-    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG is unset'
     expect "${bash_getopts[2]}" == 'INVALID OPTION -- OPTARG=-'
     expect "${bash_getopts[3]}" == 'INVALID OPTION -- OPTARG=-'
-    expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG is unset'
     expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=toggle--'
-    expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG is unset'
+    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
+    expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG'
+    expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG'
 }
 @test "${FEATURE}: long toggle, verbose" {
     compare '-t-- -t user_arg' \
@@ -55,12 +55,12 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
             '5{/^INVALID OPTION or MISSING ARGUMENT/d}' \
             's/getopts[[:alpha:]_-]*/GETOPTS-NORMALISED/' \
             's/(illegal option --) (-|toggle--)/\1 TOGGLE-NORMALISED/'
-    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG is unset'
+    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
     expect "${bash_getopts[2]}" =~ 'getopts-verbose: illegal option -- -$'
     expect "${bash_getopts[4]}" =~ 'getopts-verbose: illegal option -- -$'
-    expect "${bash_getopts[6]}" == 'toggle triggered -- OPTARG is unset'
+    expect "${bash_getopts[6]}" == 'toggle triggered -- OPTARG'
     expect "${getopts_long[1]}" =~ 'getopts_long-\w+-verbose: illegal option -- toggle--$'
-    expect "${getopts_long[3]}" == 'toggle triggered -- OPTARG is unset'
+    expect "${getopts_long[3]}" == 'toggle triggered -- OPTARG'
 }
 
 # Both implementations should see:

--- a/test/bats/github_15b.bats
+++ b/test/bats/github_15b.bats
@@ -40,9 +40,9 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
             '--toggle-- --toggle user_arg' \
             '1{/^toggle triggered/d}' \
             '/^INVALID OPTION/d'
-    expect "${bash_getopts[2]}" == 'INVALID OPTION -- OPTARG=-'
-    expect "${bash_getopts[3]}" == 'INVALID OPTION -- OPTARG=-'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=toggle--'
+    expect "${bash_getopts[2]}" == 'INVALID OPTION -- OPTARG="-"'
+    expect "${bash_getopts[3]}" == 'INVALID OPTION -- OPTARG="-"'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="toggle--"'
     expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
     expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG'
     expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG'
@@ -86,7 +86,7 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
             '--option-- --toggle user_arg' \
             '1{/(option supplied|INVALID OPTION)/d}'
     expect "${bash_getopts[1]}" == 'option supplied -- OPTARG=--'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=option--'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="option--"'
 }
 @test "${FEATURE}: long option, verbose" {
     compare '-o-- -t user_arg' \

--- a/test/bats/github_26b.bats
+++ b/test/bats/github_26b.bats
@@ -18,8 +18,8 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-longspec_with_dash_colon'
     compare '-z' \
             '---zz' \
             '/^INVALID OPTION/d'
-    expect "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG=z'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=-zz'
+    expect "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG="z"'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="-zz"'
 }
 @test "${FEATURE}: option with adjacent value, verbose" {
     compare '-z' \

--- a/test/bats/invalid_arguments.bats
+++ b/test/bats/invalid_arguments.bats
@@ -16,8 +16,8 @@ load ../test_helper
     compare '-i' \
             '--invalid' \
             '/^INVALID OPTION -- /d'
-    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG=i'
-    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=invalid'
+    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG="i"'
+    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="invalid"'
 }
 @test "${FEATURE}: long option, verbose" {
     compare '-i' \
@@ -41,8 +41,8 @@ load ../test_helper
     compare '-i user_arg' \
             '--invalid user_arg' \
             '/^INVALID OPTION -- /d'
-    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG=i'
-    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=invalid'
+    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG="i"'
+    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="invalid"'
 }
 @test "${FEATURE}: long option, extra arguments, verbose" {
     compare '-i user_arg' \
@@ -68,8 +68,8 @@ load ../test_helper
     compare '-i -- user_arg' \
             '--invalid -- user_arg' \
             '/^INVALID OPTION -- /d'
-    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG=i'
-    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=invalid'
+    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG="i"'
+    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="invalid"'
     expect  "${getopts_long[6]}" == '$@: user_arg'
 }
 @test "${FEATURE}: long option, terminator, extra arguments, verbose" {

--- a/test/bats/option_supplied.bats
+++ b/test/bats/option_supplied.bats
@@ -69,27 +69,27 @@ load ../test_helper
 @test "${FEATURE}: short option, multiple same arguments, silent" {
     compare '-o user_val1 -o user_val2' \
             '-o user_val1 -o user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val"1'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val"2'
+    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val1"'
+    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val2"'
 }
 @test "${FEATURE}: short option, multiple same arguments, verbose" {
     compare '-o user_val1 -o user_val2' \
             '-o user_val1 -o user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val"1'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val"2'
+    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val1"'
+    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val2"'
 }
 
 @test "${FEATURE}: long option, multiple same arguments, silent" {
     compare '-o user_val1 -o user_val2' \
             '--option user_val1 --option user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val"1'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val"2'
+    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val1"'
+    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val2"'
 }
 @test "${FEATURE}: long option, multiple same arguments, verbose" {
     compare '-o user_val1 -o user_val2' \
             '--option user_val1 --option user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val"1'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val"2'
+    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val1"'
+    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val2"'
 }
 
 # terminator followed by options

--- a/test/bats/option_supplied.bats
+++ b/test/bats/option_supplied.bats
@@ -134,8 +134,8 @@ load ../test_helper
     compare '-o' \
             '--option' \
             '/^MISSING ARGUMENT -- /d'
-    expect  "${bash_getopts[1]}" == 'MISSING ARGUMENT -- OPTARG=o'
-    expect  "${getopts_long[1]}" == 'MISSING ARGUMENT -- OPTARG=option'
+    expect  "${bash_getopts[1]}" == 'MISSING ARGUMENT -- OPTARG="o"'
+    expect  "${getopts_long[1]}" == 'MISSING ARGUMENT -- OPTARG="option"'
 }
 @test "${FEATURE}: long option, missing value, verbose" {
     compare '-o' \

--- a/test/bats/option_supplied.bats
+++ b/test/bats/option_supplied.bats
@@ -69,27 +69,27 @@ load ../test_helper
 @test "${FEATURE}: short option, multiple same arguments, silent" {
     compare '-o user_val1 -o user_val2' \
             '-o user_val1 -o user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG=user_val1'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG=user_val2'
+    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val"1'
+    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val"2'
 }
 @test "${FEATURE}: short option, multiple same arguments, verbose" {
     compare '-o user_val1 -o user_val2' \
             '-o user_val1 -o user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG=user_val1'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG=user_val2'
+    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val"1'
+    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val"2'
 }
 
 @test "${FEATURE}: long option, multiple same arguments, silent" {
     compare '-o user_val1 -o user_val2' \
             '--option user_val1 --option user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG=user_val1'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG=user_val2'
+    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val"1'
+    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val"2'
 }
 @test "${FEATURE}: long option, multiple same arguments, verbose" {
     compare '-o user_val1 -o user_val2' \
             '--option user_val1 --option user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG=user_val1'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG=user_val2'
+    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val"1'
+    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val"2'
 }
 
 # terminator followed by options
@@ -198,7 +198,7 @@ load ../test_helper
     compare '-ouser_val' \
             '--optionuser_val' \
             '1d'
-    expect  "${bash_getopts[1]}" == 'option supplied -- OPTARG=user_val'
+    expect  "${bash_getopts[1]}" == 'option supplied -- OPTARG="user_val"'
     expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="optionuser_val"'
 
 }
@@ -208,6 +208,6 @@ load ../test_helper
             '--optionuser_val' \
             '1d' \
             '2{/^INVALID OPTION or MISSING ARGUMENT/d}'
-    expect  "${bash_getopts[1]}" == 'option supplied -- OPTARG=user_val'
+    expect  "${bash_getopts[1]}" == 'option supplied -- OPTARG="user_val"'
     expect  "${getopts_long[1]}" =~ 'getopts_long-verbose: illegal option -- optionuser_val'
 }

--- a/test/bats/option_supplied.bats
+++ b/test/bats/option_supplied.bats
@@ -199,7 +199,7 @@ load ../test_helper
             '--optionuser_val' \
             '1d'
     expect  "${bash_getopts[1]}" == 'option supplied -- OPTARG=user_val'
-    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG=optionuser_val'
+    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="optionuser_val"'
 
 }
 

--- a/test/bats/toggle_triggered.bats
+++ b/test/bats/toggle_triggered.bats
@@ -70,26 +70,26 @@ load ../test_helper
     compare '-t -t' \
             '-t -t'
     expect  "${getopts_long[1]}" == "${getopts_long[2]}"
-    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG is unset'
+    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG'
 }
 @test "${FEATURE}: short option, multiple same arguments, verbose" {
     compare '-t -t' \
             '-t -t'
     expect  "${getopts_long[1]}" == "${getopts_long[2]}"
-    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG is unset'
+    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG'
 }
 
 @test "${FEATURE}: long option, multiple same arguments, silent" {
     compare '-t -t' \
             '--toggle --toggle'
     expect  "${getopts_long[1]}" == "${getopts_long[2]}"
-    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG is unset'
+    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG'
 }
 @test "${FEATURE}: long option, multiple same arguments, verbose" {
     compare '-t -t' \
             '--toggle --toggle'
     expect  "${getopts_long[1]}" == "${getopts_long[2]}"
-    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG is unset'
+    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG'
 }
 
 # terminator followed by options

--- a/test/bats/value_supplied.bats
+++ b/test/bats/value_supplied.bats
@@ -87,22 +87,22 @@ load ../test_helper
 @test "${FEATURE}: short option, multiple same arguments, silent" {
     compare '-v user_val1 -v user_val2' \
             '-v user_val1 -v user_val2'
-    expect "${getopts_long[1]}" == 'value supplied -- OPTARG=user_val1'
-    expect "${getopts_long[2]}" == 'value supplied -- OPTARG=user_val2'
+    expect "${getopts_long[1]}" == 'value supplied -- OPTARG="user_val1"'
+    expect "${getopts_long[2]}" == 'value supplied -- OPTARG="user_val2"'
 }
 @test "${FEATURE}: short option, multiple same arguments, verbose" {
     compare '-v user_val1 -v user_val2' \
             '-v user_val1 -v user_val2'
-    expect "${getopts_long[1]}" == 'value supplied -- OPTARG=user_val1'
-    expect "${getopts_long[2]}" == 'value supplied -- OPTARG=user_val2'
+    expect "${getopts_long[1]}" == 'value supplied -- OPTARG="user_val1"'
+    expect "${getopts_long[2]}" == 'value supplied -- OPTARG="user_val2"'
 }
 
 @test "${FEATURE}: long option, multiple same arguments, silent" {
     compare '-v user_val1 -v user_val2' \
             '--variable=user_val1 --variable=user_val2' \
             '/^OPTIND: /d'
-    expect "${getopts_long[1]}" == 'value supplied -- OPTARG=user_val1'
-    expect "${getopts_long[2]}" == 'value supplied -- OPTARG=user_val2'
+    expect "${getopts_long[1]}" == 'value supplied -- OPTARG="user_val1"'
+    expect "${getopts_long[2]}" == 'value supplied -- OPTARG="user_val2"'
     expect "${bash_getopts[6]}" == 'OPTIND: 5'
     expect "${getopts_long[6]}" == 'OPTIND: 3'
 }
@@ -110,8 +110,8 @@ load ../test_helper
     compare '-v user_val1 -v user_val2' \
             '--variable=user_val1 --variable=user_val2' \
             '/^OPTIND: /d'
-    expect "${getopts_long[1]}" == 'value supplied -- OPTARG=user_val1'
-    expect "${getopts_long[2]}" == 'value supplied -- OPTARG=user_val2'
+    expect "${getopts_long[1]}" == 'value supplied -- OPTARG="user_val1"'
+    expect "${getopts_long[2]}" == 'value supplied -- OPTARG="user_val2"'
     expect "${bash_getopts[6]}" == 'OPTIND: 5'
     expect "${getopts_long[6]}" == 'OPTIND: 3'
 }

--- a/test/bats/value_supplied.bats
+++ b/test/bats/value_supplied.bats
@@ -158,8 +158,8 @@ load ../test_helper
     compare '-v' \
             '--variable' \
             '/^MISSING ARGUMENT -- /d'
-    expect "${bash_getopts[1]}" == 'MISSING ARGUMENT -- OPTARG=v'
-    expect "${getopts_long[1]}" == 'MISSING ARGUMENT -- OPTARG=variable'
+    expect "${bash_getopts[1]}" == 'MISSING ARGUMENT -- OPTARG="v"'
+    expect "${getopts_long[1]}" == 'MISSING ARGUMENT -- OPTARG="variable"'
 }
 @test "${FEATURE}: long option, missing value, verbose" {
     compare '-v' \

--- a/test/bin/getopts-silent
+++ b/test/bin/getopts-silent
@@ -22,7 +22,7 @@ while getopts ":to:v:" OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts-verbose
+++ b/test/bin/getopts-verbose
@@ -19,7 +19,7 @@ while getopts "to:v:" OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-github_26-silent
+++ b/test/bin/getopts_long-github_26-silent
@@ -26,7 +26,7 @@ while getopts_long ':to:v: toggle option: variable: -toggle -option:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-github_26-verbose
+++ b/test/bin/getopts_long-github_26-verbose
@@ -23,7 +23,7 @@ while getopts_long 'to:v: toggle option: variable: -toggle -option:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-longspec_with_dash-silent
+++ b/test/bin/getopts_long-longspec_with_dash-silent
@@ -26,7 +26,7 @@ while getopts_long ':to:v: - toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-longspec_with_dash-verbose
+++ b/test/bin/getopts_long-longspec_with_dash-verbose
@@ -23,7 +23,7 @@ while getopts_long 'to:v: - toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-longspec_with_dash_colon-silent
+++ b/test/bin/getopts_long-longspec_with_dash_colon-silent
@@ -26,7 +26,7 @@ while getopts_long ':to:v: -: toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-longspec_with_dash_colon-verbose
+++ b/test/bin/getopts_long-longspec_with_dash_colon-verbose
@@ -23,7 +23,7 @@ while getopts_long 'to:v: -: toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-no_shortspec-silent
+++ b/test/bin/getopts_long-no_shortspec-silent
@@ -26,7 +26,7 @@ while getopts_long ': toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-no_shortspec-verbose
+++ b/test/bin/getopts_long-no_shortspec-verbose
@@ -23,7 +23,7 @@ while getopts_long ' toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-shortspec_with_dash-silent
+++ b/test/bin/getopts_long-shortspec_with_dash-silent
@@ -26,7 +26,7 @@ while getopts_long ':to:v:- toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-shortspec_with_dash-verbose
+++ b/test/bin/getopts_long-shortspec_with_dash-verbose
@@ -23,7 +23,7 @@ while getopts_long 'to:v:- toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-silent
+++ b/test/bin/getopts_long-silent
@@ -26,7 +26,7 @@ while getopts_long ':to:v: toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))

--- a/test/bin/getopts_long-verbose
+++ b/test/bin/getopts_long-verbose
@@ -23,7 +23,7 @@ while getopts_long 'to:v: toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    [[ -z "${OPTARG+SET}" ]] && echo 'OPTARG is unset' || echo "OPTARG=${OPTARG}"
+    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
 done
 
 shift $(( OPTIND - 1 ))


### PR DESCRIPTION
Implements the fix from PR #16 and updates the tests to use `declare` for validating the value of OPTARG.