### PR TITLE
[GH-18] Resolves "unbound variable" errors 

### DIFF
--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -40,7 +40,8 @@ getopts_long() {
             fi
         fi
     elif [[ "${optspec_long}" =~ (^|[[:space:]])${!optvar}([[:space:]]|$) ]]; then
-        OPTARG=
+        unset OPTARG
+        declare -g OPTARG
     else
         # Invalid option
         if [[ "${optspec_short:0:1}" == ':' ]]; then

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -37,7 +37,10 @@ getopts_long() {
     # Sanitize and normalize short optspec
     optspec_short="${optspec_short//-:}"
     optspec_short="${optspec_short//-}"
-    [[ "${!OPTIND:0:2}" == "--" ]] && optspec_short+='-:'
+    if [[ -n "${!OPTIND:-}" && "${!OPTIND:0:2}" == "--" ]]; then
+        optspec_short+='-:'
+    fi
+
 
     builtin getopts -- "${optspec_short}" "${optvar}" "${@}" || return ${?}
     [[ "${!optvar}" == '-' ]] || return 0

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -28,10 +28,9 @@ getopts_long() {
 
         # Missing argument
         if [[ -z "${OPTARG}" ]]; then
-            OPTARG="${!OPTIND}" && OPTIND=$(( OPTIND + 1 ))
-            [[ -z "${OPTARG}" ]] || return 0
-
-            if [[ "${optspec_short:0:1}" == ':' ]]; then
+            if [[ -n "${!OPTIND:-}" ]]; then
+                OPTARG="${!OPTIND}" && OPTIND=$(( OPTIND + 1 ))
+            elif [[ "${optspec_short:0:1}" == ':' ]]; then
                 OPTARG="${!optvar}" && printf -v "${optvar}" ':'
             else
                 [[ "${OPTERR}" == 0 ]] || \

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -9,7 +9,7 @@ getopts_long() {
     shift 2
 
     if [[ "${#}" == 0 ]]; then
-        local -i index
+        local -i i
         local -a args=()
         for (( i = BASH_ARGC[0] + BASH_ARGC[1] - 1; i >= BASH_ARGC[0]; i-- )); do
             args+=("${BASH_ARGV[i]}")

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -40,7 +40,7 @@ getopts_long() {
             fi
         fi
     elif [[ "${optspec_long}" =~ (^|[[:space:]])${!optvar}([[:space:]]|$) ]]; then
-        unset OPTARG
+        OPTARG=
     else
         # Invalid option
         if [[ "${optspec_short:0:1}" == ':' ]]; then

--- a/lib/getopts_long.bash
+++ b/lib/getopts_long.bash
@@ -9,10 +9,10 @@ getopts_long() {
     shift 2
 
     if [[ "${#}" == 0 ]]; then
-        local args=()
-        while [[ ${#BASH_ARGV[@]} -gt ${#args[@]} ]]; do
-            local index=$(( ${#BASH_ARGV[@]} - ${#args[@]} - 1 ))
-            args[${#args[@]}]="${BASH_ARGV[${index}]}"
+        local -i index
+        local -a args=()
+        for (( i = BASH_ARGC[0] + BASH_ARGC[1] - 1; i >= BASH_ARGC[0]; i-- )); do
+            args+=("${BASH_ARGV[i]}")
         done
         set -- "${args[@]}"
     fi

--- a/test/bats/github_18.bats
+++ b/test/bats/github_18.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+export GETOPTS_LONG_TEST_BIN='getopts_long-nounset'
+
+@test "${FEATURE}: toggles, silent" {
+    compare '-t -t -- user_arg' \
+            '-t --toggle -- user_arg'
+}
+@test "${FEATURE}: toggles, verbose" {
+    compare '-t -t -- user_arg' \
+            '-t --toggle -- user_arg'
+}
+
+@test "${FEATURE}: options, silent" {
+    compare '-o user_val1 -o user_val2 -- user_arg' \
+            '-o user_val1 --option user_val2 -- user_arg'
+}
+@test "${FEATURE}: options, verbose" {
+    compare '-o user_val1 -o user_val2 -- user_arg' \
+            '-o user_val1 --option user_val2 -- user_arg'
+}
+
+@test "${FEATURE}: variables, silent" {
+    compare '-vuser_val1 -vuser_val2 -- user_arg' \
+            '-vuser_val1 --variable=user_val2 -- user_arg'
+}
+@test "${FEATURE}: variables, verbose" {
+    compare '-vuser_val1 -vuser_val2 -- user_arg' \
+            '-vuser_val1 --variable=user_val2 -- user_arg'
+}
+
+@test "${FEATURE}: missing last argument, silent" {
+    compare '-vuser_val1 -vuser_val2 -- user_arg' \
+            '-vuser_val1 --variable=user_val2 -- user_arg'
+}
+@test "${FEATURE}: missing last argument, verbose" {
+    compare '-o' \
+            '--option'
+}

--- a/test/bats/github_18.bats
+++ b/test/bats/github_18.bats
@@ -36,5 +36,7 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-nounset'
 }
 @test "${FEATURE}: missing last argument, verbose" {
     compare '-o' \
-            '--option'
+            '--option' \
+            '1{s/getopts.+verbose:/getopts-NORMALIZED:/}' \
+            '1{s/(option requires an argument --) (o|option)$/\1 NORMALIZED/}'
 }

--- a/test/bin/getopts_long-explicit_args-silent
+++ b/test/bin/getopts_long-explicit_args-silent
@@ -58,23 +58,17 @@ variables() {
     getopts_function -vuser_val1 --variable=user_val2 -- user_arg
 }
 
-enable_extdebug='false'
-if shopt -q extdebug; then
-    enable_extdebug='true'
+(
     shopt -u extdebug
-fi
 
-: "${1:?Missing required argument -- function name}"
-function_name=${1}
-shift
+    : "${1:?Missing required argument -- function name}"
+    function_name=${1}
+    shift
 
-if declare -f "$function_name" > /dev/null; then
-    ${function_name} "$@"
-else
-    echo "Function not found -- ${function_name}"
-    exit 1
-fi
-
-if ${enable_extdebug}; then
-    shopt -s extdebug
-fi
+    if declare -f "$function_name" > /dev/null; then
+        ${function_name} "$@"
+    else
+        echo "Function not found -- ${function_name}"
+        exit 1
+    fi
+)

--- a/test/bin/getopts_long-explicit_args-verbose
+++ b/test/bin/getopts_long-explicit_args-verbose
@@ -58,23 +58,17 @@ variables() {
     getopts_function -vuser_val1 --variable=user_val2 -- user_arg
 }
 
-enable_extdebug='false'
-if shopt -q extdebug; then
-    enable_extdebug='true'
+(
     shopt -u extdebug
-fi
 
-: "${1:?Missing required parameter -- function name}"
-function_name=${1}
-shift
+    : "${1:?Missing required parameter -- function name}"
+    function_name=${1}
+    shift
 
-if declare -f "$function_name" > /dev/null; then
-    ${function_name} "$@"
-else
-    echo "Function not found -- ${function_name}"
-    exit 1
-fi
-
-if ${enable_extdebug}; then
-    shopt -s extdebug
-fi
+    if declare -f "$function_name" > /dev/null; then
+        ${function_name} "$@"
+    else
+        echo "Function not found -- ${function_name}"
+        exit 1
+    fi
+)

--- a/test/bin/getopts_long-nounset-silent
+++ b/test/bin/getopts_long-nounset-silent
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+TOPDIR="$(cd "$(dirname "${0}")"/../.. && pwd)"
+# shellcheck disable=SC1090
+source "${TOPDIR}/lib/getopts_long.bash"
+
+(
+    set -o nounset
+
+    while getopts_long ':to:v: toggle option: variable:' OPTKEY; do
+        case ${OPTKEY} in
+            't'|'toggle')
+                printf 'toggle triggered'
+                ;;
+            'o'|'option')
+                printf 'option supplied'
+                ;;
+            'v'|'variable')
+                printf 'value supplied'
+                ;;
+            '?')
+                printf "INVALID OPTION"
+                ;;
+            ':')
+                printf "MISSING ARGUMENT"
+                ;;
+            *)
+                printf "NEVER REACHED"
+                ;;
+        esac
+        printf ' -- '
+        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    done
+
+    shift $(( OPTIND - 1 ))
+
+    echo "OPTERR: ${OPTERR:-}"
+    echo "OPTKEY: ${OPTKEY:-}"
+    echo "OPTARG: ${OPTARG:-}"
+    echo "OPTIND: ${OPTIND:-}"
+
+    args=("$@")
+    declare -p args | sed -e 's/declare -a args=/$@: /'
+)

--- a/test/bin/getopts_long-nounset-verbose
+++ b/test/bin/getopts_long-nounset-verbose
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+TOPDIR="$(cd "$(dirname "${0}")"/../.. && pwd)"
+# shellcheck disable=SC1090
+source "${TOPDIR}/lib/getopts_long.bash"
+
+(
+    set -o nounset
+
+    while getopts_long 'to:v: toggle option: variable:' OPTKEY; do
+        case ${OPTKEY} in
+            't'|'toggle')
+                printf 'toggle triggered'
+                ;;
+            'o'|'option')
+                printf 'option supplied'
+                ;;
+            'v'|'variable')
+                printf 'value supplied'
+                ;;
+            '?')
+                printf "INVALID OPTION or MISSING ARGUMENT"
+                ;;
+            *)
+                printf "NEVER REACHED"
+                ;;
+        esac
+        printf ' -- '
+        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    done
+
+    shift $(( OPTIND - 1 ))
+
+    echo "OPTERR: ${OPTERR:-}"
+    echo "OPTKEY: ${OPTKEY:-}"
+    echo "OPTARG: ${OPTARG:-}"
+    echo "OPTIND: ${OPTIND:-}"
+
+    args=("$@")
+    declare -p args | sed -e 's/declare -a args=/$@: /'
+)

--- a/test/bin/getopts_long-with_extdebug-silent
+++ b/test/bin/getopts_long-with_extdebug-silent
@@ -58,23 +58,17 @@ variables() {
     getopts_function -vuser_val1 --variable=user_val2 -- user_arg
 }
 
-disable_extdebug='false'
-if ! shopt -q extdebug; then
-    disable_extdebug='true'
+(
     shopt -s extdebug
-fi
 
-: "${1:?Missing required argument -- function name}"
-function_name=${1}
-shift
+    : "${1:?Missing required argument -- function name}"
+    function_name=${1}
+    shift
 
-if declare -f "$function_name" > /dev/null; then
-    ${function_name} "$@"
-else
-    echo "Function not found -- ${function_name}"
-    exit 1
-fi
-
-if ${disable_extdebug}; then
-    shopt -u extdebug
-fi
+    if declare -f "$function_name" > /dev/null; then
+        ${function_name} "$@"
+    else
+        echo "Function not found -- ${function_name}"
+        exit 1
+    fi
+)

--- a/test/bin/getopts_long-with_extdebug-verbose
+++ b/test/bin/getopts_long-with_extdebug-verbose
@@ -58,23 +58,17 @@ variables() {
     getopts_function -vuser_val1 --variable=user_val2 -- user_arg
 }
 
-disable_extdebug='false'
-if ! shopt -q extdebug; then
-    disable_extdebug='true'
+(
     shopt -s extdebug
-fi
 
-: "${1:?Missing required parameter -- function name}"
-function_name=${1}
-shift
+    : "${1:?Missing required parameter -- function name}"
+    function_name=${1}
+    shift
 
-if declare -f "$function_name" > /dev/null; then
-    ${function_name} "$@"
-else
-    echo "Function not found -- ${function_name}"
-    exit 1
-fi
-
-if ${disable_extdebug}; then
-    shopt -u extdebug
-fi
+    if declare -f "$function_name" > /dev/null; then
+        ${function_name} "$@"
+    else
+        echo "Function not found -- ${function_name}"
+        exit 1
+    fi
+)

--- a/test/bin/getopts_long-without_extdebug-silent
+++ b/test/bin/getopts_long-without_extdebug-silent
@@ -58,23 +58,17 @@ variables() {
     getopts_function -vuser_val1 --variable=user_val2 -- user_arg
 }
 
-enable_extdebug='false'
-if shopt -q extdebug; then
-    enable_extdebug='true'
+(
     shopt -u extdebug
-fi
 
-: "${1:?Missing required argument -- function name}"
-function_name=${1}
-shift
+    : "${1:?Missing required argument -- function name}"
+    function_name=${1}
+    shift
 
-if declare -f "$function_name" > /dev/null; then
-    ${function_name} "$@"
-else
-    echo "Function not found -- ${function_name}"
-    exit 1
-fi
-
-if ${enable_extdebug}; then
-    shopt -s extdebug
-fi
+    if declare -f "$function_name" > /dev/null; then
+        ${function_name} "$@"
+    else
+        echo "Function not found -- ${function_name}"
+        exit 1
+    fi
+)

--- a/test/bin/getopts_long-without_extdebug-verbose
+++ b/test/bin/getopts_long-without_extdebug-verbose
@@ -58,23 +58,17 @@ variables() {
     getopts_function -vuser_val1 --variable=user_val2 -- user_arg
 }
 
-enable_extdebug='false'
-if shopt -q extdebug; then
-    enable_extdebug='true'
+(
     shopt -u extdebug
-fi
 
-: "${1:?Missing required parameter -- function name}"
-function_name=${1}
-shift
+    : "${1:?Missing required parameter -- function name}"
+    function_name=${1}
+    shift
 
-if declare -f "$function_name" > /dev/null; then
-    ${function_name} "$@"
-else
-    echo "Function not found -- ${function_name}"
-    exit 1
-fi
-
-if ${enable_extdebug}; then
-    shopt -s extdebug
-fi
+    if declare -f "$function_name" > /dev/null; then
+        ${function_name} "$@"
+    else
+        echo "Function not found -- ${function_name}"
+        exit 1
+    fi
+)


### PR DESCRIPTION
This PR adds checks to prevent getopts_long errors when `set -u` (shorthand for `set -o nounset`) is enabled. This setting ensures that accessing an unset or undefined variable triggers an error, which helps catch scripting mistakes and avoid unintended behaviour caused by typos or missing variables.