### PR TITLE
Upgraded all test to use `declare` instead of `echo`

### DIFF
--- a/test/bats/github_13.bats
+++ b/test/bats/github_13.bats
@@ -15,78 +15,78 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-no_shortspec'
 @test "${FEATURE}: long variable, silent" {
     compare '-v user_val' \
             '--variable=user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 @test "${FEATURE}: long variable, verbose" {
     compare '-v user_val' \
             '--variable=user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 
 @test "${FEATURE}: toggle followed by long variable, silent" {
     compare '-t -v user_val' \
             '--toggle --variable=user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[6]}" == 'OPTIND: 4'
-    expect "${getopts_long[6]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[6]}" == 'declare -i OPTIND="4"'
+    expect "${getopts_long[6]}" == 'declare -i OPTIND="3"'
 }
 @test "${FEATURE}: toggle followed by long variable, verbose" {
     compare '-t -v user_val' \
             '--toggle --variable=user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[6]}" == 'OPTIND: 4'
-    expect "${getopts_long[6]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[6]}" == 'declare -i OPTIND="4"'
+    expect "${getopts_long[6]}" == 'declare -i OPTIND="3"'
 }
 
 @test "${FEATURE}: long variable followed by toggle, silent" {
     compare '-v user_val -t' \
             '--variable=user_val --toggle' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[6]}" == 'OPTIND: 4'
-    expect "${getopts_long[6]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[6]}" == 'declare -i OPTIND="4"'
+    expect "${getopts_long[6]}" == 'declare -i OPTIND="3"'
 }
 @test "${FEATURE}: long variable followed by toggle, verbose" {
     compare '-v user_val -t'  \
             '--variable=user_val --toggle' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[6]}" == 'OPTIND: 4'
-    expect "${getopts_long[6]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[6]}" == 'declare -i OPTIND="4"'
+    expect "${getopts_long[6]}" == 'declare -i OPTIND="3"'
 }
 
 @test "${FEATURE}: terminator followed by long variable, silent" {
     compare '-t -- -v user_val' \
             '--toggle -- --variable=user_val' \
             '/^\$@: /d'
-    expect "${bash_getopts[6]}" == '$@: ([0]="-v" [1]="user_val")'
-    expect "${getopts_long[6]}" == '$@: ([0]="--variable=user_val")'
+    expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-v" [1]="user_val")'
+    expect "${getopts_long[6]}" == 'declare -a $@=([0]="--variable=user_val")'
 }
 @test "${FEATURE}: terminator followed by long variable, verbose" {
     compare '-t -- -v user_val' \
             '--toggle -- --variable=user_val' \
             '/^\$@: /d'
-    expect "${bash_getopts[6]}" == '$@: ([0]="-v" [1]="user_val")'
-    expect "${getopts_long[6]}" == '$@: ([0]="--variable=user_val")'
+    expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-v" [1]="user_val")'
+    expect "${getopts_long[6]}" == 'declare -a $@=([0]="--variable=user_val")'
 }
 
 @test "${FEATURE}: long variable followed by terminator, silent" {
     compare '-v user_val -- -t' \
             '--variable=user_val -- --toggle' \
             '/^(OPTIND|\$@): /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 4'
-    expect "${getopts_long[5]}" == 'OPTIND: 3'
-    expect "${bash_getopts[6]}" == '$@: ([0]="-t")'
-    expect "${getopts_long[6]}" == '$@: ([0]="--toggle")'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="4"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="3"'
+    expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-t")'
+    expect "${getopts_long[6]}" == 'declare -a $@=([0]="--toggle")'
 }
 @test "${FEATURE}: long variable followed by terminator, verbose" {
     compare '-v user_val -- -t'  \
             '--variable=user_val -- --toggle' \
             '/^(OPTIND|\$@): /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 4'
-    expect "${getopts_long[5]}" == 'OPTIND: 3'
-    expect "${bash_getopts[6]}" == '$@: ([0]="-t")'
-    expect "${getopts_long[6]}" == '$@: ([0]="--toggle")'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="4"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="3"'
+    expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-t")'
+    expect "${getopts_long[6]}" == 'declare -a $@=([0]="--toggle")'
 }

--- a/test/bats/github_13.bats
+++ b/test/bats/github_13.bats
@@ -58,35 +58,31 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-no_shortspec'
 }
 
 @test "${FEATURE}: terminator followed by long variable, silent" {
-    compare '-t -- -v user_val' \
+    compare '-t -- -vuser_val' \
             '--toggle -- --variable=user_val' \
-            '/^\$@: /d'
-    expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-v" [1]="user_val")'
+            '6{s/\[0]="(-v|--variable=)/[0]="-NORMALIZED=/}'
+    expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-vuser_val")'
     expect "${getopts_long[6]}" == 'declare -a $@=([0]="--variable=user_val")'
 }
 @test "${FEATURE}: terminator followed by long variable, verbose" {
-    compare '-t -- -v user_val' \
+    compare '-t -- -vuser_val' \
             '--toggle -- --variable=user_val' \
-            '/^\$@: /d'
-    expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-v" [1]="user_val")'
+            '6{s/\[0]="(-v|--variable=)/[0]="-NORMALIZED=/}'
+    expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-vuser_val")'
     expect "${getopts_long[6]}" == 'declare -a $@=([0]="--variable=user_val")'
 }
 
 @test "${FEATURE}: long variable followed by terminator, silent" {
-    compare '-v user_val -- -t' \
+    compare '-vuser_val -- -t' \
             '--variable=user_val -- --toggle' \
-            '/^(OPTIND|\$@): /d'
-    expect "${bash_getopts[5]}" == 'declare -i OPTIND="4"'
-    expect "${getopts_long[5]}" == 'declare -i OPTIND="3"'
+            '6{s/\[0]="(-t|--toggle)"/[0]="NORMALIZED"/}'
     expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-t")'
     expect "${getopts_long[6]}" == 'declare -a $@=([0]="--toggle")'
 }
 @test "${FEATURE}: long variable followed by terminator, verbose" {
-    compare '-v user_val -- -t'  \
+    compare '-vuser_val -- -t'  \
             '--variable=user_val -- --toggle' \
-            '/^(OPTIND|\$@): /d'
-    expect "${bash_getopts[5]}" == 'declare -i OPTIND="4"'
-    expect "${getopts_long[5]}" == 'declare -i OPTIND="3"'
+            '6{s/\[0]="(-t|--toggle)"/[0]="NORMALIZED"/}'
     expect "${bash_getopts[6]}" == 'declare -a $@=([0]="-t")'
     expect "${getopts_long[6]}" == 'declare -a $@=([0]="--toggle")'
 }

--- a/test/bats/github_15a.bats
+++ b/test/bats/github_15a.bats
@@ -37,9 +37,9 @@ load ../test_helper
             '--toggle-- --toggle user_arg' \
             '1{/^toggle triggered/d}' \
             '/^INVALID OPTION/d'
-    expect "${bash_getopts[2]}" == 'INVALID OPTION -- OPTARG="-"'
-    expect "${bash_getopts[3]}" == 'INVALID OPTION -- OPTARG="-"'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="toggle--"'
+    expect "${bash_getopts[2]}" == 'INVALID OPTION -- declare -- OPTARG="-"'
+    expect "${bash_getopts[3]}" == 'INVALID OPTION -- declare -- OPTARG="-"'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="toggle--"'
     expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
     expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG'
     expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG'
@@ -82,14 +82,14 @@ load ../test_helper
     compare '-o-- -t user_arg' \
             '--option-- --toggle user_arg' \
             '1{/(option supplied|INVALID OPTION)/d}'
-    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG="--"'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="option--"'
+    expect "${bash_getopts[1]}" == 'option supplied -- declare -- OPTARG="--"'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="option--"'
 }
 @test "${FEATURE}: long option, verbose" {
     compare '-o-- -t user_arg' \
             '--option-- --toggle user_arg' \
             '1{/(option supplied|illegal option)/d}' \
             '2{/^INVALID OPTION or MISSING ARGUMENT/d}'
-    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG="--"'
+    expect "${bash_getopts[1]}" == 'option supplied -- declare -- OPTARG="--"'
     expect "${getopts_long[1]}" =~ "getopts_long-verbose: illegal option -- option--$"
 }

--- a/test/bats/github_15a.bats
+++ b/test/bats/github_15a.bats
@@ -40,9 +40,9 @@ load ../test_helper
     expect "${bash_getopts[2]}" == 'INVALID OPTION -- declare -- OPTARG="-"'
     expect "${bash_getopts[3]}" == 'INVALID OPTION -- declare -- OPTARG="-"'
     expect "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="toggle--"'
-    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
-    expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG'
-    expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG'
+    expect "${bash_getopts[1]}" == 'toggle triggered -- declare -- OPTARG'
+    expect "${bash_getopts[4]}" == 'toggle triggered -- declare -- OPTARG'
+    expect "${getopts_long[2]}" == 'toggle triggered -- declare -- OPTARG'
 }
 @test "${FEATURE}: long toggle, verbose" {
     compare '-t-- -t user_arg' \
@@ -52,12 +52,12 @@ load ../test_helper
             '5{/^INVALID OPTION or MISSING ARGUMENT/d}' \
             's/getopts[[:alpha:]_-]*/GETOPTS-NORMALISED/' \
             's/(illegal option --) (-|toggle--)/\1 TOGGLE-NORMALISED/'
-    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
+    expect "${bash_getopts[1]}" == 'toggle triggered -- declare -- OPTARG'
     expect "${bash_getopts[2]}" =~ 'getopts-verbose: illegal option -- -$'
     expect "${bash_getopts[4]}" =~ 'getopts-verbose: illegal option -- -$'
-    expect "${bash_getopts[6]}" == 'toggle triggered -- OPTARG'
+    expect "${bash_getopts[6]}" == 'toggle triggered -- declare -- OPTARG'
     expect "${getopts_long[1]}" =~ 'getopts_long-verbose: illegal option -- toggle--$'
-    expect "${getopts_long[3]}" == 'toggle triggered -- OPTARG'
+    expect "${getopts_long[3]}" == 'toggle triggered -- declare -- OPTARG'
 }
 
 # Both implementations should see:

--- a/test/bats/github_15b.bats
+++ b/test/bats/github_15b.bats
@@ -40,9 +40,9 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
             '--toggle-- --toggle user_arg' \
             '1{/^toggle triggered/d}' \
             '/^INVALID OPTION/d'
-    expect "${bash_getopts[2]}" == 'INVALID OPTION -- OPTARG="-"'
-    expect "${bash_getopts[3]}" == 'INVALID OPTION -- OPTARG="-"'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="toggle--"'
+    expect "${bash_getopts[2]}" == 'INVALID OPTION -- declare -- OPTARG="-"'
+    expect "${bash_getopts[3]}" == 'INVALID OPTION -- declare -- OPTARG="-"'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="toggle--"'
     expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
     expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG'
     expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG'
@@ -85,14 +85,14 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
     compare '-o-- -t user_arg' \
             '--option-- --toggle user_arg' \
             '1{/(option supplied|INVALID OPTION)/d}'
-    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG="--"'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="option--"'
+    expect "${bash_getopts[1]}" == 'option supplied -- declare -- OPTARG="--"'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="option--"'
 }
 @test "${FEATURE}: long option, verbose" {
     compare '-o-- -t user_arg' \
             '--option-- --toggle user_arg' \
             '1{/(option supplied|illegal option)/d}' \
             '2{/^INVALID OPTION or MISSING ARGUMENT/d}'
-    expect "${bash_getopts[1]}" == 'option supplied -- OPTARG="--"'
+    expect "${bash_getopts[1]}" == 'option supplied -- declare -- OPTARG="--"'
     expect "${getopts_long[1]}" =~ "getopts_long-\w+-verbose: illegal option -- option--$"
 }

--- a/test/bats/github_15b.bats
+++ b/test/bats/github_15b.bats
@@ -43,9 +43,9 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
     expect "${bash_getopts[2]}" == 'INVALID OPTION -- declare -- OPTARG="-"'
     expect "${bash_getopts[3]}" == 'INVALID OPTION -- declare -- OPTARG="-"'
     expect "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="toggle--"'
-    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
-    expect "${bash_getopts[4]}" == 'toggle triggered -- OPTARG'
-    expect "${getopts_long[2]}" == 'toggle triggered -- OPTARG'
+    expect "${bash_getopts[1]}" == 'toggle triggered -- declare -- OPTARG'
+    expect "${bash_getopts[4]}" == 'toggle triggered -- declare -- OPTARG'
+    expect "${getopts_long[2]}" == 'toggle triggered -- declare -- OPTARG'
 }
 @test "${FEATURE}: long toggle, verbose" {
     compare '-t-- -t user_arg' \
@@ -55,12 +55,12 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-shortspec_with_dash'
             '5{/^INVALID OPTION or MISSING ARGUMENT/d}' \
             's/getopts[[:alpha:]_-]*/GETOPTS-NORMALISED/' \
             's/(illegal option --) (-|toggle--)/\1 TOGGLE-NORMALISED/'
-    expect "${bash_getopts[1]}" == 'toggle triggered -- OPTARG'
+    expect "${bash_getopts[1]}" == 'toggle triggered -- declare -- OPTARG'
     expect "${bash_getopts[2]}" =~ 'getopts-verbose: illegal option -- -$'
     expect "${bash_getopts[4]}" =~ 'getopts-verbose: illegal option -- -$'
-    expect "${bash_getopts[6]}" == 'toggle triggered -- OPTARG'
+    expect "${bash_getopts[6]}" == 'toggle triggered -- declare -- OPTARG'
     expect "${getopts_long[1]}" =~ 'getopts_long-\w+-verbose: illegal option -- toggle--$'
-    expect "${getopts_long[3]}" == 'toggle triggered -- OPTARG'
+    expect "${getopts_long[3]}" == 'toggle triggered -- declare -- OPTARG'
 }
 
 # Both implementations should see:

--- a/test/bats/github_26a.bats
+++ b/test/bats/github_26a.bats
@@ -15,14 +15,14 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-longspec_with_dash'
 @test "${FEATURE}: double toggle, silent" {
     compare '-tt' \
             '--- --toggle' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[6]}" == 'OPTIND: 2'
-    expect "${getopts_long[6]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[6]}" == 'declare -i OPTIND="2"'
+    expect "${getopts_long[6]}" == 'declare -i OPTIND="3"'
 }
 @test "${FEATURE}: double toggle, verbose" {
     compare '-tt' \
             '--- --toggle' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[6]}" == 'OPTIND: 2'
-    expect "${getopts_long[6]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[6]}" == 'declare -i OPTIND="2"'
+    expect "${getopts_long[6]}" == 'declare -i OPTIND="3"'
 }

--- a/test/bats/github_26b.bats
+++ b/test/bats/github_26b.bats
@@ -18,8 +18,8 @@ export GETOPTS_LONG_TEST_BIN='getopts_long-longspec_with_dash_colon'
     compare '-z' \
             '---zz' \
             '/^INVALID OPTION/d'
-    expect "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG="z"'
-    expect "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="-zz"'
+    expect "${bash_getopts[1]}" == 'INVALID OPTION -- declare -- OPTARG="z"'
+    expect "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="-zz"'
 }
 @test "${FEATURE}: option with adjacent value, verbose" {
     compare '-z' \

--- a/test/bats/invalid_arguments.bats
+++ b/test/bats/invalid_arguments.bats
@@ -16,8 +16,8 @@ load ../test_helper
     compare '-i' \
             '--invalid' \
             '/^INVALID OPTION -- /d'
-    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG="i"'
-    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="invalid"'
+    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- declare -- OPTARG="i"'
+    expect  "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="invalid"'
 }
 @test "${FEATURE}: long option, verbose" {
     compare '-i' \
@@ -41,8 +41,8 @@ load ../test_helper
     compare '-i user_arg' \
             '--invalid user_arg' \
             '/^INVALID OPTION -- /d'
-    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG="i"'
-    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="invalid"'
+    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- declare -- OPTARG="i"'
+    expect  "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="invalid"'
 }
 @test "${FEATURE}: long option, extra arguments, verbose" {
     compare '-i user_arg' \
@@ -68,8 +68,8 @@ load ../test_helper
     compare '-i -- user_arg' \
             '--invalid -- user_arg' \
             '/^INVALID OPTION -- /d'
-    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- OPTARG="i"'
-    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="invalid"'
+    expect  "${bash_getopts[1]}" == 'INVALID OPTION -- declare -- OPTARG="i"'
+    expect  "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="invalid"'
     expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
 }
 @test "${FEATURE}: long option, terminator, extra arguments, verbose" {

--- a/test/bats/invalid_arguments.bats
+++ b/test/bats/invalid_arguments.bats
@@ -55,13 +55,13 @@ load ../test_helper
 @test "${FEATURE}: short option, terminator, extra arguments, silent" {
     compare '-i -- user_arg' \
             '-i -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 @test "${FEATURE}: short option, terminator, extra arguments, verbose" {
     compare '-i -- user_arg' \
             '-i -- user_arg' \
             's/getopts_long-verbose/getopts-verbose/g'
-    expect  "${getopts_long[7]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[7]}" == 'declare -a $@=([0]="user_arg")'
 }
 
 @test "${FEATURE}: long option, terminator, extra arguments, silent" {
@@ -70,13 +70,13 @@ load ../test_helper
             '/^INVALID OPTION -- /d'
     expect  "${bash_getopts[1]}" == 'INVALID OPTION -- declare -- OPTARG="i"'
     expect  "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="invalid"'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 @test "${FEATURE}: long option, terminator, extra arguments, verbose" {
     compare '-i -- user_arg' \
             '--invalid -- user_arg' \
             's/getopts_long-verbose: (.*) invalid$/getopts-verbose: \1 i/g'
-    expect  "${getopts_long[7]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[7]}" == 'declare -a $@=([0]="user_arg")'
 }
 
 # terminator followed by options
@@ -84,24 +84,24 @@ load ../test_helper
 @test "${FEATURE}: terminator, short option, extra arguments, silent" {
     compare '-- -i user_arg' \
             '-- -i user_arg'
-    expect  "${getopts_long[5]}" == '$@: ([0]="-i" [1]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="-i" [1]="user_arg")'
 }
 @test "${FEATURE}: terminator, short option, extra arguments, verbose" {
     compare '-- -i user_arg' \
             '-- -i user_arg' \
             's/getopts_long-verbose/getopts-verbose/g'
-    expect  "${getopts_long[5]}" == '$@: ([0]="-i" [1]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="-i" [1]="user_arg")'
 }
 
 @test "${FEATURE}: terminator, long option, extra arguments, silent" {
     compare '-- -i user_arg' \
             '-- --invalid user_arg' \
-            '/^\$@: /d'
-    expect  "${getopts_long[5]}" == '$@: ([0]="--invalid" [1]="user_arg")'
+            '5{s/\[0]="(-i|--invalid)"/[0]="NORMALIZED"/}'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="--invalid" [1]="user_arg")'
 }
 @test "${FEATURE}: terminator, long option, extra arguments, verbose" {
     compare '-- -i user_arg' \
             '-- --invalid user_arg' \
-            '/^\$@: /d'
-    expect  "${getopts_long[5]}" == '$@: ([0]="--invalid" [1]="user_arg")'
+            '5{s/\[0]="(-i|--invalid)"/[0]="NORMALIZED"/}'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="--invalid" [1]="user_arg")'
 }

--- a/test/bats/no_arguments.bats
+++ b/test/bats/no_arguments.bats
@@ -21,10 +21,10 @@ load ../test_helper
 @test "${FEATURE}: terminator, extra arguments, silent" {
     compare '-- user_arg' \
             '-- user_arg'
-    expect  "${getopts_long[5]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="user_arg")'
 }
 @test "${FEATURE}: terminator, extra arguments, verbose" {
     compare '-- user_arg' \
             '-- user_arg'
-    expect  "${getopts_long[5]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="user_arg")'
 }

--- a/test/bats/option_supplied.bats
+++ b/test/bats/option_supplied.bats
@@ -69,27 +69,27 @@ load ../test_helper
 @test "${FEATURE}: short option, multiple same arguments, silent" {
     compare '-o user_val1 -o user_val2' \
             '-o user_val1 -o user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val1"'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val2"'
+    expect  "${getopts_long[1]}" == 'option supplied -- declare -- OPTARG="user_val1"'
+    expect  "${getopts_long[2]}" == 'option supplied -- declare -- OPTARG="user_val2"'
 }
 @test "${FEATURE}: short option, multiple same arguments, verbose" {
     compare '-o user_val1 -o user_val2' \
             '-o user_val1 -o user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val1"'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val2"'
+    expect  "${getopts_long[1]}" == 'option supplied -- declare -- OPTARG="user_val1"'
+    expect  "${getopts_long[2]}" == 'option supplied -- declare -- OPTARG="user_val2"'
 }
 
 @test "${FEATURE}: long option, multiple same arguments, silent" {
     compare '-o user_val1 -o user_val2' \
             '--option user_val1 --option user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val1"'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val2"'
+    expect  "${getopts_long[1]}" == 'option supplied -- declare -- OPTARG="user_val1"'
+    expect  "${getopts_long[2]}" == 'option supplied -- declare -- OPTARG="user_val2"'
 }
 @test "${FEATURE}: long option, multiple same arguments, verbose" {
     compare '-o user_val1 -o user_val2' \
             '--option user_val1 --option user_val2'
-    expect  "${getopts_long[1]}" == 'option supplied -- OPTARG="user_val1"'
-    expect  "${getopts_long[2]}" == 'option supplied -- OPTARG="user_val2"'
+    expect  "${getopts_long[1]}" == 'option supplied -- declare -- OPTARG="user_val1"'
+    expect  "${getopts_long[2]}" == 'option supplied -- declare -- OPTARG="user_val2"'
 }
 
 # terminator followed by options
@@ -108,14 +108,16 @@ load ../test_helper
 @test "${FEATURE}: terminator, long option, extra arguments, silent" {
     compare '-- -o user_val user_arg' \
             '-- --option user_val user_arg' \
-            '/^\$@: /d'
-    expect  "${getopts_long[5]}" == '$@: ([0]="--option" [1]="user_val" [2]="user_arg")'
+            '5{s/\[0]="(-o|--option)"/[0]="NORMALIZED"/}'
+    expect  "${bash_getopts[5]}" == 'declare -a $@=([0]="-o" [1]="user_val" [2]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="--option" [1]="user_val" [2]="user_arg")'
 }
 @test "${FEATURE}: terminator, long option, extra arguments, verbose" {
     compare '-- -o user_val user_arg' \
             '-- --option user_val user_arg' \
-            '/^\$@: /d'
-    expect  "${getopts_long[5]}" == '$@: ([0]="--option" [1]="user_val" [2]="user_arg")'
+            '5{s/\[0]="(-o|--option)"/[0]="NORMALIZED"/}'
+    expect  "${bash_getopts[5]}" == 'declare -a $@=([0]="-o" [1]="user_val" [2]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="--option" [1]="user_val" [2]="user_arg")'
 }
 
 # option without an argument
@@ -134,8 +136,8 @@ load ../test_helper
     compare '-o' \
             '--option' \
             '/^MISSING ARGUMENT -- /d'
-    expect  "${bash_getopts[1]}" == 'MISSING ARGUMENT -- OPTARG="o"'
-    expect  "${getopts_long[1]}" == 'MISSING ARGUMENT -- OPTARG="option"'
+    expect  "${bash_getopts[1]}" == 'MISSING ARGUMENT -- declare -- OPTARG="o"'
+    expect  "${getopts_long[1]}" == 'MISSING ARGUMENT -- declare -- OPTARG="option"'
 }
 @test "${FEATURE}: long option, missing value, verbose" {
     compare '-o' \
@@ -198,8 +200,8 @@ load ../test_helper
     compare '-ouser_val' \
             '--optionuser_val' \
             '1d'
-    expect  "${bash_getopts[1]}" == 'option supplied -- OPTARG="user_val"'
-    expect  "${getopts_long[1]}" == 'INVALID OPTION -- OPTARG="optionuser_val"'
+    expect  "${bash_getopts[1]}" == 'option supplied -- declare -- OPTARG="user_val"'
+    expect  "${getopts_long[1]}" == 'INVALID OPTION -- declare -- OPTARG="optionuser_val"'
 
 }
 
@@ -208,6 +210,6 @@ load ../test_helper
             '--optionuser_val' \
             '1d' \
             '2{/^INVALID OPTION or MISSING ARGUMENT/d}'
-    expect  "${bash_getopts[1]}" == 'option supplied -- OPTARG="user_val"'
+    expect  "${bash_getopts[1]}" == 'option supplied -- declare -- OPTARG="user_val"'
     expect  "${getopts_long[1]}" =~ 'getopts_long-verbose: illegal option -- optionuser_val'
 }

--- a/test/bats/option_supplied.bats
+++ b/test/bats/option_supplied.bats
@@ -45,23 +45,23 @@ load ../test_helper
 @test "${FEATURE}: short option, terminator, extra arguments, silent" {
     compare '-o user_val -- user_arg' \
             '-o user_val -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 @test "${FEATURE}: short option, terminator, extra arguments, verbose" {
     compare '-o user_val -- user_arg' \
             '-o user_val -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 
 @test "${FEATURE}: long option, terminator, extra arguments, silent" {
     compare '-o user_val -- user_arg' \
             '--option user_val -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 @test "${FEATURE}: long option, terminator, extra arguments, verbose" {
     compare '-o user_val -- user_arg' \
             '--option user_val -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 
 # multiple same arguments
@@ -97,12 +97,12 @@ load ../test_helper
 @test "${FEATURE}: terminator, short option, extra arguments, silent" {
     compare '-- -o user_val user_arg' \
             '-- -o user_val user_arg'
-    expect  "${getopts_long[5]}" == '$@: ([0]="-o" [1]="user_val" [2]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="-o" [1]="user_val" [2]="user_arg")'
 }
 @test "${FEATURE}: terminator, short option, extra arguments, verbose" {
     compare '-- -o user_val user_arg' \
             '-- -o user_val user_arg'
-    expect  "${getopts_long[5]}" == '$@: ([0]="-o" [1]="user_val" [2]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="-o" [1]="user_val" [2]="user_arg")'
 }
 
 @test "${FEATURE}: terminator, long option, extra arguments, silent" {

--- a/test/bats/toggle_triggered.bats
+++ b/test/bats/toggle_triggered.bats
@@ -45,23 +45,23 @@ load ../test_helper
 @test "${FEATURE}: short option, terminator, extra arguments, silent" {
     compare '-t -- user_arg' \
             '-t -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 @test "${FEATURE}: short option, terminator, extra arguments, verbose" {
     compare '-t -- user_arg' \
             '-t -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 
 @test "${FEATURE}: long option, terminator, extra arguments, silent" {
     compare '-t -- user_arg' \
             '--toggle -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 @test "${FEATURE}: long option, terminator, extra arguments, verbose" {
     compare '-t -- user_arg' \
             '--toggle -- user_arg'
-    expect  "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect  "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 
 # multiple same arguments
@@ -70,26 +70,26 @@ load ../test_helper
     compare '-t -t' \
             '-t -t'
     expect  "${getopts_long[1]}" == "${getopts_long[2]}"
-    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG'
+    expect  "${getopts_long[1]}" == 'toggle triggered -- declare -- OPTARG'
 }
 @test "${FEATURE}: short option, multiple same arguments, verbose" {
     compare '-t -t' \
             '-t -t'
     expect  "${getopts_long[1]}" == "${getopts_long[2]}"
-    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG'
+    expect  "${getopts_long[1]}" == 'toggle triggered -- declare -- OPTARG'
 }
 
 @test "${FEATURE}: long option, multiple same arguments, silent" {
     compare '-t -t' \
             '--toggle --toggle'
     expect  "${getopts_long[1]}" == "${getopts_long[2]}"
-    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG'
+    expect  "${getopts_long[1]}" == 'toggle triggered -- declare -- OPTARG'
 }
 @test "${FEATURE}: long option, multiple same arguments, verbose" {
     compare '-t -t' \
             '--toggle --toggle'
     expect  "${getopts_long[1]}" == "${getopts_long[2]}"
-    expect  "${getopts_long[1]}" == 'toggle triggered -- OPTARG'
+    expect  "${getopts_long[1]}" == 'toggle triggered -- declare -- OPTARG'
 }
 
 # terminator followed by options
@@ -97,23 +97,25 @@ load ../test_helper
 @test "${FEATURE}: terminator, short option, extra arguments, silent" {
     compare '-- -t user_arg' \
             '-- -t user_arg'
-    expect  "${getopts_long[5]}" == '$@: ([0]="-t" [1]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="-t" [1]="user_arg")'
 }
 @test "${FEATURE}: terminator, short option, extra arguments, verbose" {
     compare '-- -t user_arg' \
             '-- -t user_arg'
-    expect  "${getopts_long[5]}" == '$@: ([0]="-t" [1]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="-t" [1]="user_arg")'
 }
 
 @test "${FEATURE}: terminator, long option, extra arguments, silent" {
     compare '-- -t user_arg' \
             '-- --toggle user_arg' \
-            '/^\$@: /d'
-    expect  "${getopts_long[5]}" == '$@: ([0]="--toggle" [1]="user_arg")'
+            '5{s/\[0]="(-t|--toggle)"/[0]="NORMALIZED"/}'
+    expect  "${bash_getopts[5]}" == 'declare -a $@=([0]="-t" [1]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="--toggle" [1]="user_arg")'
 }
 @test "${FEATURE}: terminator, long option, extra arguments, verbose" {
     compare '-- -t user_arg' \
             '-- --toggle user_arg' \
-            '/^\$@: /d'
-    expect  "${getopts_long[5]}" == '$@: ([0]="--toggle" [1]="user_arg")'
+            '5{s/\[0]="(-t|--toggle)"/[0]="NORMALIZED"/}'
+    expect  "${bash_getopts[5]}" == 'declare -a $@=([0]="-t" [1]="user_arg")'
+    expect  "${getopts_long[5]}" == 'declare -a $@=([0]="--toggle" [1]="user_arg")'
 }

--- a/test/bats/value_supplied.bats
+++ b/test/bats/value_supplied.bats
@@ -14,16 +14,16 @@ load ../test_helper
 @test "${FEATURE}: long option, silent" {
     compare '-v user_val' \
             '--variable=user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 @test "${FEATURE}: long option, verbose" {
     compare '-v user_val' \
             '--variable=user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 
 # extra arguments
@@ -40,16 +40,16 @@ load ../test_helper
 @test "${FEATURE}: long option, extra arguments, silent" {
     compare '-v user_val user_arg' \
             '--variable=user_val user_arg' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 @test "${FEATURE}: long option, extra arguments, verbose" {
     compare '-v user_val user_arg' \
             '--variable=user_val user_arg' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 
 # extra arguments with terminator
@@ -57,29 +57,29 @@ load ../test_helper
 @test "${FEATURE}: short option, terminator, extra arguments, silent" {
     compare '-v user_val -- user_arg' \
             '-v user_val -- user_arg'
-    expect "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 @test "${FEATURE}: short option, terminator, extra arguments, verbose" {
     compare '-v user_val -- user_arg' \
             '-v user_val -- user_arg'
-    expect "${getopts_long[6]}" == '$@: ([0]="user_arg")'
+    expect "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
 }
 
 @test "${FEATURE}: long option, terminator, extra arguments, silent" {
     compare '-v user_val -- user_arg' \
             '--variable=user_val -- user_arg' \
-            '/^OPTIND: /d'
-    expect "${getopts_long[6]}" == '$@: ([0]="user_arg")'
-    expect "${bash_getopts[5]}" == 'OPTIND: 4'
-    expect "${getopts_long[5]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="4"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="3"'
 }
 @test "${FEATURE}: long option, terminator, extra arguments, verbose" {
     compare '-v user_val -- user_arg' \
             '--variable=user_val -- user_arg' \
-            '/^OPTIND: /d'
-    expect "${getopts_long[6]}" == '$@: ([0]="user_arg")'
-    expect "${bash_getopts[5]}" == 'OPTIND: 4'
-    expect "${getopts_long[5]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${getopts_long[6]}" == 'declare -a $@=([0]="user_arg")'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="4"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="3"'
 }
 
 # multiple same arguments
@@ -87,33 +87,33 @@ load ../test_helper
 @test "${FEATURE}: short option, multiple same arguments, silent" {
     compare '-v user_val1 -v user_val2' \
             '-v user_val1 -v user_val2'
-    expect "${getopts_long[1]}" == 'value supplied -- OPTARG="user_val1"'
-    expect "${getopts_long[2]}" == 'value supplied -- OPTARG="user_val2"'
+    expect "${getopts_long[1]}" == 'value supplied -- declare -- OPTARG="user_val1"'
+    expect "${getopts_long[2]}" == 'value supplied -- declare -- OPTARG="user_val2"'
 }
 @test "${FEATURE}: short option, multiple same arguments, verbose" {
     compare '-v user_val1 -v user_val2' \
             '-v user_val1 -v user_val2'
-    expect "${getopts_long[1]}" == 'value supplied -- OPTARG="user_val1"'
-    expect "${getopts_long[2]}" == 'value supplied -- OPTARG="user_val2"'
+    expect "${getopts_long[1]}" == 'value supplied -- declare -- OPTARG="user_val1"'
+    expect "${getopts_long[2]}" == 'value supplied -- declare -- OPTARG="user_val2"'
 }
 
 @test "${FEATURE}: long option, multiple same arguments, silent" {
     compare '-v user_val1 -v user_val2' \
             '--variable=user_val1 --variable=user_val2' \
-            '/^OPTIND: /d'
-    expect "${getopts_long[1]}" == 'value supplied -- OPTARG="user_val1"'
-    expect "${getopts_long[2]}" == 'value supplied -- OPTARG="user_val2"'
-    expect "${bash_getopts[6]}" == 'OPTIND: 5'
-    expect "${getopts_long[6]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${getopts_long[1]}" == 'value supplied -- declare -- OPTARG="user_val1"'
+    expect "${getopts_long[2]}" == 'value supplied -- declare -- OPTARG="user_val2"'
+    expect "${bash_getopts[6]}" == 'declare -i OPTIND="5"'
+    expect "${getopts_long[6]}" == 'declare -i OPTIND="3"'
 }
 @test "${FEATURE}: long option, multiple same arguments, verbose" {
     compare '-v user_val1 -v user_val2' \
             '--variable=user_val1 --variable=user_val2' \
-            '/^OPTIND: /d'
-    expect "${getopts_long[1]}" == 'value supplied -- OPTARG="user_val1"'
-    expect "${getopts_long[2]}" == 'value supplied -- OPTARG="user_val2"'
-    expect "${bash_getopts[6]}" == 'OPTIND: 5'
-    expect "${getopts_long[6]}" == 'OPTIND: 3'
+            '/^declare -i OPTIND=/d'
+    expect "${getopts_long[1]}" == 'value supplied -- declare -- OPTARG="user_val1"'
+    expect "${getopts_long[2]}" == 'value supplied -- declare -- OPTARG="user_val2"'
+    expect "${bash_getopts[6]}" == 'declare -i OPTIND="5"'
+    expect "${getopts_long[6]}" == 'declare -i OPTIND="3"'
 }
 
 # terminator followed by options
@@ -121,25 +121,27 @@ load ../test_helper
 @test "${FEATURE}: terminator, short option, extra arguments, silent" {
     compare '-- -v user_val user_arg' \
             '-- -v user_val user_arg'
-    expect "${getopts_long[5]}" == '$@: ([0]="-v" [1]="user_val" [2]="user_arg")'
+    expect "${getopts_long[5]}" == 'declare -a $@=([0]="-v" [1]="user_val" [2]="user_arg")'
 }
 @test "${FEATURE}: terminator, short option, extra arguments, verbose" {
     compare '-- -v user_val user_arg' \
             '-- -v user_val user_arg'
-    expect "${getopts_long[5]}" == '$@: ([0]="-v" [1]="user_val" [2]="user_arg")'
+    expect "${getopts_long[5]}" == 'declare -a $@=([0]="-v" [1]="user_val" [2]="user_arg")'
 }
 
 @test "${FEATURE}: terminator, long option, extra arguments, silent" {
-    compare '-- -v user_val user_arg' \
+    compare '-- -vuser_val user_arg' \
             '-- --variable=user_val user_arg' \
-            '/^\$@: /d'
-    expect "${getopts_long[5]}" == '$@: ([0]="--variable=user_val" [1]="user_arg")'
+            '5{s/\[0]="(-v|--variable=)/[0]="-NORMALIZED=/}'
+    expect "${bash_getopts[5]}" == 'declare -a $@=([0]="-vuser_val" [1]="user_arg")'
+    expect "${getopts_long[5]}" == 'declare -a $@=([0]="--variable=user_val" [1]="user_arg")'
 }
 @test "${FEATURE}: terminator, long option, extra arguments, verbose" {
-    compare '-- -v user_val user_arg' \
+    compare '-- -vuser_val user_arg' \
             '-- --variable=user_val user_arg' \
-            '/^\$@: /d'
-    expect "${getopts_long[5]}" == '$@: ([0]="--variable=user_val" [1]="user_arg")'
+            '5{s/\[0]="(-v|--variable=)/[0]="-NORMALIZED=/}'
+    expect "${bash_getopts[5]}" == 'declare -a $@=([0]="-vuser_val" [1]="user_arg")'
+    expect "${getopts_long[5]}" == 'declare -a $@=([0]="--variable=user_val" [1]="user_arg")'
 }
 
 # variable without an argument
@@ -181,16 +183,16 @@ load ../test_helper
 @test "${FEATURE}: long option, value starts with -, silent" {
     compare '-v -user_val' \
             '--variable=-user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 @test "${FEATURE}: long option, value starts with -, verbose" {
     compare '-v -user_val' \
             '--variable=-user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 
 # option with a value that start with an equals sign
@@ -207,14 +209,14 @@ load ../test_helper
 @test "${FEATURE}: long option, value starts with =, silent" {
     compare '-v =user_val' \
             '--variable==user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }
 @test "${FEATURE}: long option, value starts with =, verbose" {
     compare '-v =user_val' \
             '--variable==user_val' \
-            '/^OPTIND: /d'
-    expect "${bash_getopts[5]}" == 'OPTIND: 3'
-    expect "${getopts_long[5]}" == 'OPTIND: 2'
+            '/^declare -i OPTIND=/d'
+    expect "${bash_getopts[5]}" == 'declare -i OPTIND="3"'
+    expect "${getopts_long[5]}" == 'declare -i OPTIND="2"'
 }

--- a/test/bats/value_supplied.bats
+++ b/test/bats/value_supplied.bats
@@ -158,8 +158,8 @@ load ../test_helper
     compare '-v' \
             '--variable' \
             '/^MISSING ARGUMENT -- /d'
-    expect "${bash_getopts[1]}" == 'MISSING ARGUMENT -- OPTARG="v"'
-    expect "${getopts_long[1]}" == 'MISSING ARGUMENT -- OPTARG="variable"'
+    expect "${bash_getopts[1]}" == 'MISSING ARGUMENT -- declare -- OPTARG="v"'
+    expect "${getopts_long[1]}" == 'MISSING ARGUMENT -- declare -- OPTARG="variable"'
 }
 @test "${FEATURE}: long option, missing value, verbose" {
     compare '-v' \

--- a/test/bin/getopts-silent
+++ b/test/bin/getopts-silent
@@ -22,15 +22,15 @@ while getopts ":to:v:" OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 | sed -e 's/script_args/$@/' | grep -oe 'declare.*'

--- a/test/bin/getopts-verbose
+++ b/test/bin/getopts-verbose
@@ -19,15 +19,15 @@ while getopts "to:v:" OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 | sed -e 's/script_args/$@/' | grep -oe 'declare.*'

--- a/test/bin/getopts_long-explicit_args-silent
+++ b/test/bin/getopts_long-explicit_args-silent
@@ -39,7 +39,8 @@ getopts_function() {
 
     local function_args=("$@")
     declare -p function_args \
-        | sed -e 's/script_args/$@/' | grep -oe 'declare.*'
+        | sed -e 's/function_args/$@/' \
+        | grep -oe 'declare.*'
 }
 
 proxy() {

--- a/test/bin/getopts_long-explicit_args-silent
+++ b/test/bin/getopts_long-explicit_args-silent
@@ -27,19 +27,19 @@ getopts_function() {
                 ;;
         esac
         printf ' -- '
-        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+        declare -p OPTARG 2>&1 | grep -oe 'declare.*'
     done
 
     shift $(( OPTIND - 1 ))
 
-    echo "OPTERR: ${OPTERR}"
-    echo "OPTKEY: ${OPTKEY}"
-    echo "OPTARG: ${OPTARG}"
-    echo "OPTIND: ${OPTIND}"
+    declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+    declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+    declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
     local function_args=("$@")
     declare -p function_args \
-        | sed -e 's/declare -a function_args=/$@: /'
+        | sed -e 's/script_args/$@/' | grep -oe 'declare.*'
 }
 
 proxy() {

--- a/test/bin/getopts_long-explicit_args-verbose
+++ b/test/bin/getopts_long-explicit_args-verbose
@@ -39,7 +39,8 @@ getopts_function() {
 
     local function_args=("$@")
     declare -p function_args \
-        | sed -e 's/script_args/$@/' | grep -oe 'declare.*'
+        | sed -e 's/function_args/$@/' \
+        | grep -oe 'declare.*'
 }
 
 proxy() {

--- a/test/bin/getopts_long-explicit_args-verbose
+++ b/test/bin/getopts_long-explicit_args-verbose
@@ -27,19 +27,19 @@ getopts_function() {
                 ;;
         esac
         printf ' -- '
-        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+        declare -p OPTARG 2>&1 | grep -oe 'declare.*'
     done
 
     shift $(( OPTIND - 1 ))
 
-    echo "OPTERR: ${OPTERR}"
-    echo "OPTKEY: ${OPTKEY}"
-    echo "OPTARG: ${OPTARG}"
-    echo "OPTIND: ${OPTIND}"
+    declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+    declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+    declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
     local function_args=("$@")
     declare -p function_args \
-        | sed -e 's/declare -a function_args=/$@: /'
+        | sed -e 's/script_args/$@/' | grep -oe 'declare.*'
 }
 
 proxy() {

--- a/test/bin/getopts_long-github_26-silent
+++ b/test/bin/getopts_long-github_26-silent
@@ -26,15 +26,17 @@ while getopts_long ':to:v: toggle option: variable: -toggle -option:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-github_26-verbose
+++ b/test/bin/getopts_long-github_26-verbose
@@ -23,15 +23,17 @@ while getopts_long 'to:v: toggle option: variable: -toggle -option:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-longspec_with_dash-silent
+++ b/test/bin/getopts_long-longspec_with_dash-silent
@@ -26,15 +26,17 @@ while getopts_long ':to:v: - toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-longspec_with_dash-verbose
+++ b/test/bin/getopts_long-longspec_with_dash-verbose
@@ -23,15 +23,17 @@ while getopts_long 'to:v: - toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-longspec_with_dash_colon-silent
+++ b/test/bin/getopts_long-longspec_with_dash_colon-silent
@@ -26,15 +26,17 @@ while getopts_long ':to:v: -: toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-longspec_with_dash_colon-verbose
+++ b/test/bin/getopts_long-longspec_with_dash_colon-verbose
@@ -23,15 +23,17 @@ while getopts_long 'to:v: -: toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-no_shortspec-silent
+++ b/test/bin/getopts_long-no_shortspec-silent
@@ -26,15 +26,17 @@ while getopts_long ': toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-no_shortspec-verbose
+++ b/test/bin/getopts_long-no_shortspec-verbose
@@ -23,15 +23,17 @@ while getopts_long ' toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-nounset-silent
+++ b/test/bin/getopts_long-nounset-silent
@@ -29,16 +29,18 @@ source "${TOPDIR}/lib/getopts_long.bash"
                 ;;
         esac
         printf ' -- '
-        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+        declare -p OPTARG 2>&1 | grep -oe 'declare.*'
     done
 
     shift $(( OPTIND - 1 ))
 
-    echo "OPTERR: ${OPTERR:-}"
-    echo "OPTKEY: ${OPTKEY:-}"
-    echo "OPTARG: ${OPTARG:-}"
-    echo "OPTIND: ${OPTIND:-}"
+    declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+    declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+    declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-    args=("$@")
-    declare -p args | sed -e 's/declare -a args=/$@: /'
+    script_args=("$@")
+    declare -p script_args 2>&1 \
+        | sed -e 's/script_args/$@/' \
+        | grep -oe 'declare.*'
 )

--- a/test/bin/getopts_long-nounset-verbose
+++ b/test/bin/getopts_long-nounset-verbose
@@ -26,16 +26,18 @@ source "${TOPDIR}/lib/getopts_long.bash"
                 ;;
         esac
         printf ' -- '
-        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+        declare -p OPTARG 2>&1 | grep -oe 'declare.*'
     done
 
     shift $(( OPTIND - 1 ))
 
-    echo "OPTERR: ${OPTERR:-}"
-    echo "OPTKEY: ${OPTKEY:-}"
-    echo "OPTARG: ${OPTARG:-}"
-    echo "OPTIND: ${OPTIND:-}"
+    declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+    declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+    declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-    args=("$@")
-    declare -p args | sed -e 's/declare -a args=/$@: /'
+    script_args=("$@")
+    declare -p script_args 2>&1 \
+        | sed -e 's/script_args/$@/' \
+        | grep -oe 'declare.*'
 )

--- a/test/bin/getopts_long-shortspec_with_dash-silent
+++ b/test/bin/getopts_long-shortspec_with_dash-silent
@@ -26,15 +26,17 @@ while getopts_long ':to:v:- toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-shortspec_with_dash-verbose
+++ b/test/bin/getopts_long-shortspec_with_dash-verbose
@@ -23,15 +23,17 @@ while getopts_long 'to:v:- toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-silent
+++ b/test/bin/getopts_long-silent
@@ -26,15 +26,15 @@ while getopts_long ':to:v: toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 | sed -e 's/script_args/$@/' | grep -oe 'declare.*'

--- a/test/bin/getopts_long-silent
+++ b/test/bin/getopts_long-silent
@@ -37,4 +37,6 @@ declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
 script_args=("$@")
-declare -p script_args 2>&1 | sed -e 's/script_args/$@/' | grep -oe 'declare.*'
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-verbose
+++ b/test/bin/getopts_long-verbose
@@ -34,4 +34,6 @@ declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
 script_args=("$@")
-declare -p script_args 2>&1 | sed -e 's/script_args/$@/' | grep -oe 'declare.*'
+declare -p script_args 2>&1 \
+    | sed -e 's/script_args/$@/' \
+    | grep -oe 'declare.*'

--- a/test/bin/getopts_long-verbose
+++ b/test/bin/getopts_long-verbose
@@ -23,15 +23,15 @@ while getopts_long 'to:v: toggle option: variable:' OPTKEY; do
             ;;
     esac
     printf ' -- '
-    declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
 done
 
 shift $(( OPTIND - 1 ))
 
-echo "OPTERR: ${OPTERR}"
-echo "OPTKEY: ${OPTKEY}"
-echo "OPTARG: ${OPTARG}"
-echo "OPTIND: ${OPTIND}"
+declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-args=("$@")
-declare -p args | sed -e 's/declare -a args=/$@: /'
+script_args=("$@")
+declare -p script_args 2>&1 | sed -e 's/script_args/$@/' | grep -oe 'declare.*'

--- a/test/bin/getopts_long-with_extdebug-silent
+++ b/test/bin/getopts_long-with_extdebug-silent
@@ -27,19 +27,20 @@ getopts_function() {
                 ;;
         esac
         printf ' -- '
-        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+        declare -p OPTARG 2>&1 | grep -oe 'declare.*'
     done
 
     shift $(( OPTIND - 1 ))
 
-    echo "OPTERR: ${OPTERR}"
-    echo "OPTKEY: ${OPTKEY}"
-    echo "OPTARG: ${OPTARG}"
-    echo "OPTIND: ${OPTIND}"
+    declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+    declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+    declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-    local function_args=("$@")
-    declare -p function_args \
-        | sed -e 's/declare -a function_args=/$@: /'
+    function_args=("$@")
+    declare -p function_args 2>&1 \
+        | sed -e 's/function_args/$@/' \
+        | grep -oe 'declare.*'
 }
 
 proxy() {

--- a/test/bin/getopts_long-with_extdebug-verbose
+++ b/test/bin/getopts_long-with_extdebug-verbose
@@ -27,19 +27,20 @@ getopts_function() {
                 ;;
         esac
         printf ' -- '
-        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+        declare -p OPTARG 2>&1 | grep -oe 'declare.*'
     done
 
     shift $(( OPTIND - 1 ))
 
-    echo "OPTERR: ${OPTERR}"
-    echo "OPTKEY: ${OPTKEY}"
-    echo "OPTARG: ${OPTARG}"
-    echo "OPTIND: ${OPTIND}"
+    declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+    declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+    declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-    local function_args=("$@")
-    declare -p function_args \
-        | sed -e 's/declare -a function_args=/$@: /'
+    function_args=("$@")
+    declare -p function_args 2>&1 \
+        | sed -e 's/function_args/$@/' \
+        | grep -oe 'declare.*'
 }
 
 proxy() {

--- a/test/bin/getopts_long-without_extdebug-silent
+++ b/test/bin/getopts_long-without_extdebug-silent
@@ -27,19 +27,20 @@ getopts_function() {
                 ;;
         esac
         printf ' -- '
-        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+        declare -p OPTARG 2>&1 | grep -oe 'declare.*'
     done
 
     shift $(( OPTIND - 1 ))
 
-    echo "OPTERR: ${OPTERR}"
-    echo "OPTKEY: ${OPTKEY}"
-    echo "OPTARG: ${OPTARG}"
-    echo "OPTIND: ${OPTIND}"
+    declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+    declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+    declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-    local function_args=("$@")
-    declare -p function_args \
-        | sed -e 's/declare -a function_args=/$@: /'
+    function_args=("$@")
+    declare -p function_args 2>&1 \
+        | sed -e 's/function_args/$@/' \
+        | grep -oe 'declare.*'
 }
 
 proxy() {

--- a/test/bin/getopts_long-without_extdebug-verbose
+++ b/test/bin/getopts_long-without_extdebug-verbose
@@ -27,19 +27,20 @@ getopts_function() {
                 ;;
         esac
         printf ' -- '
-        declare -p OPTARG 2>&1 | grep -oe 'OPTARG.*'
+        declare -p OPTARG 2>&1 | grep -oe 'declare.*'
     done
 
     shift $(( OPTIND - 1 ))
 
-    echo "OPTERR: ${OPTERR}"
-    echo "OPTKEY: ${OPTKEY}"
-    echo "OPTARG: ${OPTARG}"
-    echo "OPTIND: ${OPTIND}"
+    declare -p OPTERR 2>&1 | grep -oe 'declare.*'
+    declare -p OPTKEY 2>&1 | grep -oe 'declare.*'
+    declare -p OPTARG 2>&1 | grep -oe 'declare.*'
+    declare -p OPTIND 2>&1 | grep -oe 'declare.*'
 
-    local function_args=("$@")
-    declare -p function_args \
-        | sed -e 's/declare -a function_args=/$@: /'
+    function_args=("$@")
+    declare -p function_args 2>&1 \
+        | sed -e 's/function_args/$@/' \
+        | grep -oe 'declare.*'
 }
 
 proxy() {


### PR DESCRIPTION
This simplifies comparing bash builtin `getopts` and `getopts_long`, especially where one sets a blank variable, while the other one unsets it instead.